### PR TITLE
Use transparent-looking background

### DIFF
--- a/style.css
+++ b/style.css
@@ -136,7 +136,9 @@ button {
 }
 
 #output-container img {
-    background-color: var(--background);
+    background: 
+    repeating-conic-gradient(#808080 0% 25%, transparent 0% 50%) 
+      50% / 20px 20px;
     width: 100%;
     image-rendering: pixelated;
 }


### PR DESCRIPTION
The grayscale background made it a bit hard for me to tell what the output picture looks like, so I replaced it with this background.

![image](https://github.com/jobtalle/SDFMaker/assets/10220080/6883d62d-eac7-45da-932c-e3607c4e6415)

I have no idea if that's preferable, so I figured I'd ask. 